### PR TITLE
Fix bug in hosts variable reference

### DIFF
--- a/infrastructure/users.yml
+++ b/infrastructure/users.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Modify Users
-  hosts: $hosts
+  hosts: "{{ hosts }}"
   gather_facts: False
   sudo: True
   roles:


### PR DESCRIPTION
Update the `$hosts` variable reference to `'{{ hosts }}'`